### PR TITLE
update-rodio-to-0.13: Update the "rodio" dependency to version 0.13 and bump crate version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffmpeg-decoder"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["tarkah <admin@tarkah.dev>"]
 edition = "2018"
 license = "MIT"
@@ -25,7 +25,7 @@ ffmpeg-sys-next = { version = "4.3.4", default-features=false, features=['avcode
 thiserror = "1.0"
 log = "0.4"
 
-rodio = { version = "0.11", default-features=false, optional=true }
+rodio = { version = "0.13", default-features=false, optional=true }
 
 [workspace]
 members = [

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 ffmpeg-decoder = { path = "../", features = ['rodio_source'] }
 
-rodio = { version = "0.11", default-features=false }
+rodio = { version = "0.13", default-features=false }
 
 anyhow = "1.0"
 env_logger = "0.7"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -47,8 +47,8 @@ fn decode_to_file(input: PathBuf) -> Result<(), Error> {
 fn play_file(input: PathBuf) -> Result<(), Error> {
     let decoder = ffmpeg_decoder::Decoder::open(&input)?;
 
-    let device = rodio::default_output_device().unwrap();
-    let sink = Sink::new(&device);
+    let (_, stream_handle) = rodio::OutputStream::try_default()?;
+    let sink = Sink::try_new(&stream_handle)?;
 
     sink.append(decoder);
     sink.play();


### PR DESCRIPTION
Hello,

This pull request updates the `rodio` dependency, updates the corresponding code in the sample CLI and also bumps the crate version, because:

* `rodio` APIs have changed and developers may want to integrate it in more recent code
* Recent `rodio` version also have fixed critical bugs with MP3 decoding
* Once merged, more potential code will be able to be compatible with your library

Also, thanks for your nice crate!